### PR TITLE
Add sampling option key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- changelog -->
 
+## [4.1.0](https://github.com/spandex-project/spandex/compare/4.0.0...4.1.0) (2024-01-05)
+
+### Features:
+
+* Allow for passing in options for the sampling strategy by @JerzyDziala in https://github.com/surgeventures/spandex/pull/2
+
 ## [4.0.0](https://github.com/spandex-project/spandex/compare/3.2.0...4.0.0) (2023-10-30)
 
 ### Features:

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -57,7 +57,7 @@ defmodule Spandex.Tracer do
                    services: {:keyword, :atom},
                    strategy: :atom,
                    sampling_strategy: :atom,
-                   sampling_options: {:keyword, :any},
+                   sampling_options: :keyword,
                    sender: :atom,
                    trace_key: :atom
                  ],
@@ -82,7 +82,8 @@ defmodule Spandex.Tracer do
                    sampling_strategy:
                      "The sampling strategy to use. It makes the decision of whether to sample out a trace or not.",
                    sampling_options: "Any additional options to pass to the sampling strategy."
-                 ]
+                 ],
+                  extra_keys?: true
                )
 
   @all_tracer_opts @tracer_opts
@@ -91,7 +92,6 @@ defmodule Spandex.Tracer do
                      annotate: "Span Creation",
                      add_required?: false
                    )
-                   |> Map.put(:extra_keys?, false)
 
   @doc """
   A schema for the opts that a tracer accepts.

--- a/lib/tracer.ex
+++ b/lib/tracer.ex
@@ -57,6 +57,7 @@ defmodule Spandex.Tracer do
                    services: {:keyword, :atom},
                    strategy: :atom,
                    sampling_strategy: :atom,
+                   sampling_options: {:keyword, :any},
                    sender: :atom,
                    trace_key: :atom
                  ],
@@ -64,7 +65,8 @@ defmodule Spandex.Tracer do
                  defaults: [
                    disabled?: false,
                    services: [],
-                   strategy: Spandex.Strategy.Pdict
+                   strategy: Spandex.Strategy.Pdict,
+                   sampling_options: []
                  ],
                  describe: [
                    adapter: "The third party adapter to use",
@@ -78,7 +80,8 @@ defmodule Spandex.Tracer do
                    services: "A mapping of service name to the default span types.",
                    strategy: "The storage and tracing strategy. Currently only supports local process dictionary.",
                    sampling_strategy:
-                     "The sampling strategy to use. It makes the decision of whether to sample out a trace or not."
+                     "The sampling strategy to use. It makes the decision of whether to sample out a trace or not.",
+                   sampling_options: "Any additional options to pass to the sampling strategy."
                  ]
                )
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Spandex.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex"
-  @version "4.1.0-pre.1"
+  @version "4.1.0-pre.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Spandex.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex"
-  @version "4.1.0"
+  @version "4.1.0-pre.1"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Spandex.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/surgeventures/spandex"
-  @version "4.0.0"
+  @version "4.1.0"
 
   def project do
     [


### PR DESCRIPTION
This adds `sampling_options` key to the tracer config schema